### PR TITLE
Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -1,6 +1,11 @@
 name: Run tests for Meaningless
 on:
   workflow_dispatch:
+    inputs:
+      run_system_tests:
+        description: 'Run system tests'
+        required: true
+        default: 'true'
   schedule:
     # Every Sunday at 1:45PM UTC
     - cron: '45 13 * * 0'
@@ -17,9 +22,9 @@ jobs:
     name: Build for ${{ matrix.os }} with Python ${{ matrix.python-version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v2.2.2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -78,7 +83,8 @@ jobs:
           python unit_tests_bible_list_extractor.py
           echo "Running Base Downloader unit tests..."
           python unit_tests_bible_base_downloader.py
-      - name: Run system tests
+      - if: github.event.inputs.run_system_tests == 'true'
+        name: Run system tests
         run: |
           cd test
           echo "Running Bible translation system tests..."


### PR DESCRIPTION
This addresses the various deprecation warnings that show up in the automated weekly test runs, such as:
- "Node.js 12 actions are deprecated..."
- "The ``set-output`` command is deprecated and will be disabled soon..."
- "The `save-state` command is deprecated and will be disabled soon..."

Also adding an option to skip the system tests, since they can take a considerable amount of time to complete.