### PR TITLE
Fix failing unit tests when using newer versions of ruamel.yaml

### DIFF
--- a/test/static/unit_tests_bible_base_downloader/WEB/test_base_download_chapters.yaml
+++ b/test/static/unit_tests_bible_base_downloader/WEB/test_base_download_chapters.yaml
@@ -32,8 +32,8 @@
       and the truth isn’t in him. '
     5: '⁵ But God’s love has most certainly been perfected in whoever keeps his word.
       This is how we know that we are in him: '
-    6: "⁶ he who says he remains in him ought himself also to walk just like he walked.\
-      \ \n"
+    6: "⁶ he who says he remains in him ought himself also to walk just like he walked.
+      \n"
     7: '⁷ Brothers, I write no new commandment to you, but an old commandment which
       you had from the beginning. The old commandment is the word which you heard
       from the beginning. '
@@ -43,23 +43,23 @@
       even until now. '
     10: '¹⁰ He who loves his brother remains in the light, and there is no occasion
       for stumbling in him. '
-    11: "¹¹ But he who hates his brother is in the darkness, and walks in the darkness,\
-      \ and doesn’t know where he is going, because the darkness has blinded his eyes.\
-      \ \n"
-    12: "¹² I write to you, little children, because your sins are forgiven you for\
-      \ his name’s sake. \n"
-    13: "¹³ I write to you, fathers, because you know him who is from the beginning.\n\
-      I write to you, young men, because you have overcome the evil one.\nI write\
-      \ to you, little children, because you know the Father. \n"
-    14: "¹⁴ I have written to you, fathers, because you know him who is from the beginning.\n\
-      I have written to you, young men, because you are strong, and the word of God\
-      \ remains in you, and you have overcome the evil one. \n"
+    11: "¹¹ But he who hates his brother is in the darkness, and walks in the darkness,
+      and doesn’t know where he is going, because the darkness has blinded his eyes.
+      \n"
+    12: "¹² I write to you, little children, because your sins are forgiven you for
+      his name’s sake. \n"
+    13: "¹³ I write to you, fathers, because you know him who is from the beginning.\n
+      I write to you, young men, because you have overcome the evil one.\nI write
+      to you, little children, because you know the Father. \n"
+    14: "¹⁴ I have written to you, fathers, because you know him who is from the beginning.\n
+      I have written to you, young men, because you are strong, and the word of God
+      remains in you, and you have overcome the evil one. \n"
     15: '¹⁵ Don’t love the world or the things that are in the world. If anyone loves
       the world, the Father’s love isn’t in him. '
     16: '¹⁶ For all that is in the world, the lust of the flesh, the lust of the eyes,
       and the pride of life, isn’t the Father’s, but is the world’s. '
-    17: "¹⁷ The world is passing away with its lusts, but he who does God’s will remains\
-      \ forever. \n"
+    17: "¹⁷ The world is passing away with its lusts, but he who does God’s will remains
+      forever. \n"
     18: '¹⁸ Little children, these are the end times, and as you heard that the Antichrist
       is coming, even now many antichrists have arisen. By this we know that it is
       the final hour. '
@@ -71,8 +71,8 @@
       you know it, and because no lie is of the truth. '
     22: '²² Who is the liar but he who denies that Jesus is the Christ? This is the
       Antichrist, he who denies the Father and the Son. '
-    23: "²³ Whoever denies the Son doesn’t have the Father. He who confesses the Son\
-      \ has the Father also. \n"
+    23: "²³ Whoever denies the Son doesn’t have the Father. He who confesses the Son
+      has the Father also. \n"
     24: '²⁴ Therefore, as for you, let that remain in you which you heard from the
       beginning. If that which you heard from the beginning remains in you, you also
       will remain in the Son, and in the Father. '
@@ -97,8 +97,8 @@
     3: '³ Everyone who has this hope set on him purifies himself, even as he is pure. '
     4: '⁴ Everyone who sins also commits lawlessness. Sin is lawlessness. '
     5: '⁵ You know that he was revealed to take away our sins, and no sin is in him. '
-    6: "⁶ Whoever remains in him doesn’t sin. Whoever sins hasn’t seen him and doesn’t\
-      \ know him. \n"
+    6: "⁶ Whoever remains in him doesn’t sin. Whoever sins hasn’t seen him and doesn’t
+      know him. \n"
     7: '⁷ Little children, let no one lead you astray. He who does righteousness is
       righteous, even as he is righteous. '
     8: '⁸ He who sins is of the devil, for the devil has been sinning from the beginning.
@@ -111,13 +111,13 @@
       his brother. '
     11: '¹¹ For this is the message which you heard from the beginning, that we should
       love one another; '
-    12: "¹² unlike Cain, who was of the evil one, and killed his brother. Why did\
-      \ he kill him? Because his deeds were evil, and his brother’s righteous. \n"
+    12: "¹² unlike Cain, who was of the evil one, and killed his brother. Why did
+      he kill him? Because his deeds were evil, and his brother’s righteous. \n"
     13: '¹³ Don’t be surprised, my brothers, if the world hates you. '
     14: '¹⁴ We know that we have passed out of death into life, because we love the
       brothers. He who doesn’t love his brother remains in death. '
-    15: "¹⁵ Whoever hates his brother is a murderer, and you know that no murderer\
-      \ has eternal life remaining in him. \n"
+    15: "¹⁵ Whoever hates his brother is a murderer, and you know that no murderer
+      has eternal life remaining in him. \n"
     16: '¹⁶ By this we know love, because he laid down his life for us. And we ought
       to lay down our lives for the brothers. '
     17: '¹⁷ But whoever has the world’s goods and sees his brother in need, then closes

--- a/test/static/unit_tests_bible_base_downloader/WEB/test_base_download_with_ascii_punctuation.yaml
+++ b/test/static/unit_tests_bible_base_downloader/WEB/test_base_download_with_ascii_punctuation.yaml
@@ -20,16 +20,16 @@ Ecclesiastes:
       is that which shall be done: and there is no new thing under the sun. '
     10: '¹⁰ Is there a thing of which it may be said, "Behold, this is new?" It has
       been long ago, in the ages which were before us. '
-    11: "¹¹ There is no memory of the former; neither shall there be any memory of\
-      \ the latter that are to come, among those that shall come after. \n"
+    11: "¹¹ There is no memory of the former; neither shall there be any memory of
+      the latter that are to come, among those that shall come after. \n"
     12: '¹² I, the Preacher, was king over Israel in Jerusalem. '
     13: '¹³ I applied my heart to seek and to search out by wisdom concerning all
       that is done under the sky. It is a heavy burden that God has given to the sons
       of men to be afflicted with. '
     14: '¹⁴ I have seen all the works that are done under the sun; and behold, all
       is vanity and a chasing after wind. '
-    15: "¹⁵ That which is crooked can't be made straight; and that which is lacking\
-      \ can't be counted. "
+    15: "¹⁵ That which is crooked can't be made straight; and that which is lacking
+      can't be counted. "
     16: '¹⁶ I said to myself, "Behold, I have obtained for myself great wisdom above
       all who were before me in Jerusalem. Yes, my heart has had great experience
       of wisdom and knowledge." '
@@ -40,8 +40,8 @@ Ecclesiastes:
   2:
     1: '¹ I said in my heart, "Come now, I will test you with mirth: therefore enjoy
       pleasure;" and behold, this also was vanity. '
-    2: "² I said of laughter, \"It is foolishness;\" and of mirth, \"What does it\
-      \ accomplish?\" \n"
+    2: "² I said of laughter, \"It is foolishness;\" and of mirth, \"What does it
+      accomplish?\" \n"
     3: '³ I searched in my heart how to cheer my flesh with wine, my heart yet guiding
       me with wisdom, and how to lay hold of folly, until I might see what it was
       good for the sons of men that they should do under heaven all the days of their
@@ -58,30 +58,30 @@ Ecclesiastes:
       the sons of men: musical instruments, and that of all sorts. '
     9: '⁹ So I was great, and increased more than all who were before me in Jerusalem.
       My wisdom also remained with me. '
-    10: "¹⁰ Whatever my eyes desired, I didn't keep from them. I didn't withhold my\
-      \ heart from any joy, for my heart rejoiced because of all my labor, and this\
-      \ was my portion from all my labor. "
-    11: "¹¹ Then I looked at all the works that my hands had worked, and at the labor\
-      \ that I had labored to do; and behold, all was vanity and a chasing after wind,\
-      \ and there was no profit under the sun. \n"
-    12: "¹² I turned myself to consider wisdom, madness, and folly; for what can the\
-      \ king's successor do? Just that which has been done long ago. "
+    10: "¹⁰ Whatever my eyes desired, I didn't keep from them. I didn't withhold my
+      heart from any joy, for my heart rejoiced because of all my labor, and this
+      was my portion from all my labor. "
+    11: "¹¹ Then I looked at all the works that my hands had worked, and at the labor
+      that I had labored to do; and behold, all was vanity and a chasing after wind,
+      and there was no profit under the sun. \n"
+    12: "¹² I turned myself to consider wisdom, madness, and folly; for what can the
+      king's successor do? Just that which has been done long ago. "
     13: '¹³ Then I saw that wisdom excels folly, as far as light excels darkness. '
-    14: "¹⁴ The wise man's eyes are in his head, and the fool walks in darkness-and\
-      \ yet I perceived that one event happens to them all. "
+    14: "¹⁴ The wise man's eyes are in his head, and the fool walks in darkness-and
+      yet I perceived that one event happens to them all. "
     15: '¹⁵ Then I said in my heart, "As it happens to the fool, so will it happen
       even to me; and why was I then more wise?" Then I said in my heart that this
       also is vanity. '
-    16: "¹⁶ For of the wise man, even as of the fool, there is no memory forever,\
-      \ since in the days to come all will have been long forgotten. Indeed, the wise\
-      \ man must die just like the fool! \n"
+    16: "¹⁶ For of the wise man, even as of the fool, there is no memory forever,
+      since in the days to come all will have been long forgotten. Indeed, the wise
+      man must die just like the fool! \n"
     17: '¹⁷ So I hated life, because the work that is worked under the sun was grievous
       to me; for all is vanity and a chasing after wind. '
     18: '¹⁸ I hated all my labor in which I labored under the sun, because I must
       leave it to the man who comes after me. '
-    19: "¹⁹ Who knows whether he will be a wise man or a fool? Yet he will have rule\
-      \ over all of my labor in which I have labored, and in which I have shown myself\
-      \ wise under the sun. This also is vanity. \n"
+    19: "¹⁹ Who knows whether he will be a wise man or a fool? Yet he will have rule
+      over all of my labor in which I have labored, and in which I have shown myself
+      wise under the sun. This also is vanity. \n"
     20: '²⁰ Therefore I began to cause my heart to despair concerning all the labor
       in which I had labored under the sun. '
     21: '²¹ For there is a man whose labor is with wisdom, with knowledge, and with
@@ -99,28 +99,28 @@ Ecclesiastes:
       to the sinner he gives travail, to gather and to heap up, that he may give to
       him who pleases God. This also is vanity and a chasing after wind.
   3:
-    1: "¹ For everything there is a season, and a time for every purpose under heaven:\
-      \ \n"
-    2: "² a time to be born,\n    and a time to die;\na time to plant,\n    and a\
-      \ time to pluck up that which is planted;\n"
-    3: "³ a time to kill,\n    and a time to heal;\na time to break down,\n    and\
-      \ a time to build up;\n"
-    4: "⁴ a time to weep,\n    and a time to laugh;\na time to mourn,\n    and a time\
-      \ to dance;\n"
-    5: "⁵ a time to cast away stones,\n    and a time to gather stones together;\n\
+    1: "¹ For everything there is a season, and a time for every purpose under heaven:
+      \n"
+    2: "² a time to be born,\n    and a time to die;\na time to plant,\n    and a
+      time to pluck up that which is planted;\n"
+    3: "³ a time to kill,\n    and a time to heal;\na time to break down,\n    and
+      a time to build up;\n"
+    4: "⁴ a time to weep,\n    and a time to laugh;\na time to mourn,\n    and a time
+      to dance;\n"
+    5: "⁵ a time to cast away stones,\n    and a time to gather stones together;\n
       a time to embrace,\n    and a time to refrain from embracing;\n"
-    6: "⁶ a time to seek,\n    and a time to lose;\na time to keep,\n    and a time\
-      \ to cast away;\n"
-    7: "⁷ a time to tear,\n    and a time to sew;\na time to keep silence,\n    and\
-      \ a time to speak;\n"
-    8: "⁸ a time to love,\n    and a time to hate;\na time for war,\n    and a time\
-      \ for peace. \n"
+    6: "⁶ a time to seek,\n    and a time to lose;\na time to keep,\n    and a time
+      to cast away;\n"
+    7: "⁷ a time to tear,\n    and a time to sew;\na time to keep silence,\n    and
+      a time to speak;\n"
+    8: "⁸ a time to love,\n    and a time to hate;\na time for war,\n    and a time
+      for peace. \n"
     9: '⁹ What profit has he who works in that in which he labors? '
     10: '¹⁰ I have seen the burden which God has given to the sons of men to be afflicted
       with. '
-    11: "¹¹ He has made everything beautiful in its time. He has also set eternity\
-      \ in their hearts, yet so that man can't find out the work that God has done\
-      \ from the beginning even to the end. "
+    11: "¹¹ He has made everything beautiful in its time. He has also set eternity
+      in their hearts, yet so that man can't find out the work that God has done from
+      the beginning even to the end. "
     12: '¹² I know that there is nothing better for them than to rejoice, and to do
       good as long as they live. '
     13: '¹³ Also that every man should eat and drink, and enjoy good in all his labor,
@@ -128,8 +128,8 @@ Ecclesiastes:
     14: '¹⁴ I know that whatever God does, it shall be forever. Nothing can be added
       to it, nor anything taken from it; and God has done it, that men should fear
       before him. '
-    15: "¹⁵ That which is has been long ago, and that which is to be has been long\
-      \ ago. God seeks again that which is passed away. \n"
+    15: "¹⁵ That which is has been long ago, and that which is to be has been long
+      ago. God seeks again that which is passed away. \n"
     16: '¹⁶ Moreover I saw under the sun, in the place of justice, that wickedness
       was there; and in the place of righteousness, that wickedness was there. '
     17: '¹⁷ I said in my heart, "God will judge the righteous and the wicked; for
@@ -140,8 +140,8 @@ Ecclesiastes:
       thing happens to them. As the one dies, so the other dies. Yes, they have all
       one breath; and man has no advantage over the animals; for all is vanity. '
     20: '²⁰ All go to one place. All are from the dust, and all turn to dust again. '
-    21: "²¹ Who knows the spirit of man, whether it goes upward, and the spirit of\
-      \ the animal, whether it goes downward to the earth?\" \n"
+    21: "²¹ Who knows the spirit of man, whether it goes upward, and the spirit of
+      the animal, whether it goes downward to the earth?\" \n"
     22: '²² Therefore I saw that there is nothing better than that a man should rejoice
       in his works; for that is his portion: for who can bring him to see what will
       be after him?'
@@ -153,25 +153,25 @@ Ecclesiastes:
       who are yet alive. '
     3: '³ Yes, better than them both is him who has not yet been, who has not seen
       the evil work that is done under the sun. '
-    4: "⁴ Then I saw all the labor and achievement that is the envy of a man's neighbor.\
-      \ This also is vanity and a striving after wind. \n"
+    4: "⁴ Then I saw all the labor and achievement that is the envy of a man's neighbor.
+      This also is vanity and a striving after wind. \n"
     5: '⁵ The fool folds his hands together and ruins himself. '
-    6: "⁶ Better is a handful, with quietness, than two handfuls with labor and chasing\
-      \ after wind. \n"
+    6: "⁶ Better is a handful, with quietness, than two handfuls with labor and chasing
+      after wind. \n"
     7: '⁷ Then I returned and saw vanity under the sun. '
-    8: "⁸ There is one who is alone, and he has neither son nor brother. There is\
-      \ no end to all of his labor, neither are his eyes satisfied with wealth. \"\
-      For whom then, do I labor and deprive my soul of enjoyment?\" This also is vanity.\
-      \ Yes, it is a miserable business. \n"
+    8: "⁸ There is one who is alone, and he has neither son nor brother. There is
+      no end to all of his labor, neither are his eyes satisfied with wealth. \"For
+      whom then, do I labor and deprive my soul of enjoyment?\" This also is vanity.
+      Yes, it is a miserable business. \n"
     9: '⁹ Two are better than one, because they have a good reward for their labor. '
-    10: "¹⁰ For if they fall, the one will lift up his fellow; but woe to him who\
-      \ is alone when he falls, and doesn't have another to lift him up. "
+    10: "¹⁰ For if they fall, the one will lift up his fellow; but woe to him who
+      is alone when he falls, and doesn't have another to lift him up. "
     11: '¹¹ Again, if two lie together, then they have warmth; but how can one keep
       warm alone? '
-    12: "¹² If a man prevails against one who is alone, two shall withstand him; and\
-      \ a threefold cord is not quickly broken. \n"
-    13: "¹³ Better is a poor and wise youth than an old and foolish king who doesn't\
-      \ know how to receive admonition any more. "
+    12: "¹² If a man prevails against one who is alone, two shall withstand him; and
+      a threefold cord is not quickly broken. \n"
+    13: "¹³ Better is a poor and wise youth than an old and foolish king who doesn't
+      know how to receive admonition any more. "
     14: '¹⁴ For out of prison he came out to be king; yes, even in his kingdom he
       was born poor. '
     15: '¹⁵ I saw all the living who walk under the sun, that they were with the youth,
@@ -180,43 +180,43 @@ Ecclesiastes:
       those who come after shall not rejoice in him. Surely this also is vanity and
       a chasing after wind.
   5:
-    1: "¹ Guard your steps when you go to God's house; for to draw near to listen\
-      \ is better than to give the sacrifice of fools, for they don't know that they\
-      \ do evil. "
-    2: "² Don't be rash with your mouth, and don't let your heart be hasty to utter\
-      \ anything before God; for God is in heaven, and you on earth. Therefore let\
-      \ your words be few. "
-    3: "³ For as a dream comes with a multitude of cares, so a fool's speech with\
-      \ a multitude of words. "
-    4: "⁴ When you vow a vow to God, don't defer to pay it; for he has no pleasure\
-      \ in fools. Pay that which you vow. "
+    1: "¹ Guard your steps when you go to God's house; for to draw near to listen
+      is better than to give the sacrifice of fools, for they don't know that they
+      do evil. "
+    2: "² Don't be rash with your mouth, and don't let your heart be hasty to utter
+      anything before God; for God is in heaven, and you on earth. Therefore let your
+      words be few. "
+    3: "³ For as a dream comes with a multitude of cares, so a fool's speech with
+      a multitude of words. "
+    4: "⁴ When you vow a vow to God, don't defer to pay it; for he has no pleasure
+      in fools. Pay that which you vow. "
     5: '⁵ It is better that you should not vow, than that you should vow and not pay. '
-    6: "⁶ Don't allow your mouth to lead you into sin. Don't protest before the messenger\
-      \ that this was a mistake. Why should God be angry at your voice, and destroy\
-      \ the work of your hands? "
-    7: "⁷ For in the multitude of dreams there are vanities, as well as in many words;\
-      \ but you must fear God. \n"
-    8: "⁸ If you see the oppression of the poor, and the violent taking away of justice\
-      \ and righteousness in a district, don't marvel at the matter, for one official\
-      \ is eyed by a higher one, and there are officials over them. "
-    9: "⁹ Moreover the profit of the earth is for all. The king profits from the field.\
-      \ \n"
+    6: "⁶ Don't allow your mouth to lead you into sin. Don't protest before the messenger
+      that this was a mistake. Why should God be angry at your voice, and destroy
+      the work of your hands? "
+    7: "⁷ For in the multitude of dreams there are vanities, as well as in many words;
+      but you must fear God. \n"
+    8: "⁸ If you see the oppression of the poor, and the violent taking away of justice
+      and righteousness in a district, don't marvel at the matter, for one official
+      is eyed by a higher one, and there are officials over them. "
+    9: "⁹ Moreover the profit of the earth is for all. The king profits from the field.
+      \n"
     10: '¹⁰ He who loves silver shall not be satisfied with silver; nor he who loves
       abundance, with increase: this also is vanity. '
-    11: "¹¹ When goods increase, those who eat them are increased; and what advantage\
-      \ is there to its owner, except to feast on them with his eyes? \n"
-    12: "¹² The sleep of a laboring man is sweet, whether he eats little or much;\
-      \ but the abundance of the rich will not allow him to sleep. \n"
+    11: "¹¹ When goods increase, those who eat them are increased; and what advantage
+      is there to its owner, except to feast on them with his eyes? \n"
+    12: "¹² The sleep of a laboring man is sweet, whether he eats little or much;
+      but the abundance of the rich will not allow him to sleep. \n"
     13: '¹³ There is a grievous evil which I have seen under the sun: wealth kept
       by its owner to his harm. '
     14: '¹⁴ Those riches perish by misfortune, and if he has fathered a son, there
       is nothing in his hand. '
-    15: "¹⁵ As he came out of his mother's womb, naked shall he go again as he came,\
-      \ and shall take nothing for his labor, which he may carry away in his hand. "
+    15: "¹⁵ As he came out of his mother's womb, naked shall he go again as he came,
+      and shall take nothing for his labor, which he may carry away in his hand. "
     16: '¹⁶ This also is a grievous evil, that in all points as he came, so shall
       he go. And what profit does he have who labors for the wind? '
-    17: "¹⁷ All his days he also eats in darkness, he is frustrated, and has sickness\
-      \ and wrath. \n"
+    17: "¹⁷ All his days he also eats in darkness, he is frustrated, and has sickness
+      and wrath. \n"
     18: '¹⁸ Behold, that which I have seen to be good and proper is for one to eat
       and to drink, and to enjoy good in all his labor, in which he labors under the
       sun, all the days of his life which God has given him; for this is his portion. '
@@ -227,9 +227,9 @@ Ecclesiastes:
       him with the joy of his heart.
   6:
     1: '¹ There is an evil which I have seen under the sun, and it is heavy on men: '
-    2: "² a man to whom God gives riches, wealth, and honor, so that he lacks nothing\
-      \ for his soul of all that he desires, yet God gives him no power to eat of\
-      \ it, but an alien eats it. This is vanity, and it is an evil disease. \n"
+    2: "² a man to whom God gives riches, wealth, and honor, so that he lacks nothing
+      for his soul of all that he desires, yet God gives him no power to eat of it,
+      but an alien eats it. This is vanity, and it is an evil disease. \n"
     3: '³ If a man fathers a hundred children, and lives many years, so that the days
       of his years are many, but his soul is not filled with good, and moreover he
       has no burial; I say that a stillborn child is better than he: '
@@ -237,8 +237,8 @@ Ecclesiastes:
       with darkness. '
     5: '⁵ Moreover it has not seen the sun nor known it. This has rest rather than
       the other. '
-    6: "⁶ Yes, though he live a thousand years twice told, and yet fails to enjoy\
-      \ good, don't all go to one place? "
+    6: "⁶ Yes, though he live a thousand years twice told, and yet fails to enjoy
+      good, don't all go to one place? "
     7: '⁷ All the labor of man is for his mouth, and yet the appetite is not filled. '
     8: '⁸ For what advantage has the wise more than the fool? What has the poor man,
       that knows how to walk before the living? '
@@ -251,8 +251,8 @@ Ecclesiastes:
       which he spends like a shadow? For who can tell a man what will be after him
       under the sun?
   7:
-    1: "¹ A good name is better than fine perfume; and the day of death better than\
-      \ the day of one's birth. "
+    1: "¹ A good name is better than fine perfume; and the day of death better than
+      the day of one's birth. "
     2: '² It is better to go to the house of mourning than to go to the house of feasting;
       for that is the end of all men, and the living should take this to heart. '
     3: '³ Sorrow is better than laughter; for by the sadness of the face the heart
@@ -264,47 +264,47 @@ Ecclesiastes:
     6: '⁶ For as the crackling of thorns under a pot, so is the laughter of the fool.
       This also is vanity. '
     7: '⁷ Surely extortion makes the wise man foolish; and a bribe destroys the understanding. '
-    8: "⁸ Better is the end of a thing than its beginning.\nThe patient in spirit\
-      \ is better than the proud in spirit. "
-    9: "⁹ Don't be hasty in your spirit to be angry, for anger rests in the bosom\
-      \ of fools. "
-    10: "¹⁰ Don't say, \"Why were the former days better than these?\" For you do\
-      \ not ask wisely about this. \n"
+    8: "⁸ Better is the end of a thing than its beginning.\nThe patient in spirit
+      is better than the proud in spirit. "
+    9: "⁹ Don't be hasty in your spirit to be angry, for anger rests in the bosom
+      of fools. "
+    10: "¹⁰ Don't say, \"Why were the former days better than these?\" For you do
+      not ask wisely about this. \n"
     11: '¹¹ Wisdom is as good as an inheritance. Yes, it is more excellent for those
       who see the sun. '
-    12: "¹² For wisdom is a defense, even as money is a defense; but the excellency\
-      \ of knowledge is that wisdom preserves the life of him who has it. \n"
+    12: "¹² For wisdom is a defense, even as money is a defense; but the excellency
+      of knowledge is that wisdom preserves the life of him who has it. \n"
     13: '¹³ Consider the work of God, for who can make that straight, which he has
       made crooked? '
-    14: "¹⁴ In the day of prosperity be joyful, and in the day of adversity consider;\
-      \ yes, God has made the one side by side with the other, to the end that man\
-      \ should not find out anything after him. \n"
+    14: "¹⁴ In the day of prosperity be joyful, and in the day of adversity consider;
+      yes, God has made the one side by side with the other, to the end that man should
+      not find out anything after him. \n"
     15: '¹⁵ All this I have seen in my days of vanity: there is a righteous man who
       perishes in his righteousness, and there is a wicked man who lives long in his
       evildoing. '
-    16: "¹⁶ Don't be overly righteous, neither make yourself overly wise. Why should\
-      \ you destroy yourself? "
-    17: "¹⁷ Don't be too wicked, neither be foolish. Why should you die before your\
-      \ time? "
-    18: "¹⁸ It is good that you should take hold of this. Yes, also don't withdraw\
-      \ your hand from that; for he who fears God will come out of them all. "
+    16: "¹⁶ Don't be overly righteous, neither make yourself overly wise. Why should
+      you destroy yourself? "
+    17: "¹⁷ Don't be too wicked, neither be foolish. Why should you die before your
+      time? "
+    18: "¹⁸ It is good that you should take hold of this. Yes, also don't withdraw
+      your hand from that; for he who fears God will come out of them all. "
     19: '¹⁹ Wisdom is a strength to the wise man more than ten rulers who are in a
       city. '
-    20: "²⁰ Surely there is not a righteous man on earth who does good and doesn't\
-      \ sin. "
-    21: "²¹ Also don't take heed to all words that are spoken, lest you hear your\
-      \ servant curse you; "
+    20: "²⁰ Surely there is not a righteous man on earth who does good and doesn't
+      sin. "
+    21: "²¹ Also don't take heed to all words that are spoken, lest you hear your
+      servant curse you; "
     22: '²² for often your own heart knows that you yourself have likewise cursed
       others. '
     23: '²³ All this I have proved in wisdom. I said, "I will be wise;" but it was
       far from me. '
     24: '²⁴ That which is, is far off and exceedingly deep. Who can find it out? '
-    25: "²⁵ I turned around, and my heart sought to know and to search out, and to\
-      \ seek wisdom and the scheme of things, and to know that wickedness is stupidity,\
-      \ and that foolishness is madness. \n"
-    26: "²⁶ I find more bitter than death the woman whose heart is snares and traps,\
-      \ whose hands are chains. Whoever pleases God shall escape from her; but the\
-      \ sinner will be ensnared by her. \n"
+    25: "²⁵ I turned around, and my heart sought to know and to search out, and to
+      seek wisdom and the scheme of things, and to know that wickedness is stupidity,
+      and that foolishness is madness. \n"
+    26: "²⁶ I find more bitter than death the woman whose heart is snares and traps,
+      whose hands are chains. Whoever pleases God shall escape from her; but the sinner
+      will be ensnared by her. \n"
     27: '²⁷ "Behold, I have found this," says the Preacher, "to one another, to find
       out the scheme '
     28: '²⁸ which my soul still seeks, but I have not found. I have found one man
@@ -312,22 +312,22 @@ Ecclesiastes:
     29: '²⁹ Behold, I have only found this: that God made man upright; but they search
       for many schemes."'
   8:
-    1: "¹ Who is like the wise man? And who knows the interpretation of a thing? A\
-      \ man's wisdom makes his face shine, and the hardness of his face is changed. "
+    1: "¹ Who is like the wise man? And who knows the interpretation of a thing? A
+      man's wisdom makes his face shine, and the hardness of his face is changed. "
     2: "² I say, \"Keep the king's command!\" because of the oath to God. "
-    3: "³ Don't be hasty to go out of his presence. Don't persist in an evil thing,\
-      \ for he does whatever pleases him, "
+    3: "³ Don't be hasty to go out of his presence. Don't persist in an evil thing,
+      for he does whatever pleases him, "
     4: "⁴ for the king's word is supreme. Who can say to him, \"What are you doing?\"\
       \ "
     5: '⁵ Whoever keeps the commandment shall not come to harm, and his wise heart
       will know the time and procedure. '
     6: '⁶ For there is a time and procedure for every purpose, although the misery
       of man is heavy on him. '
-    7: "⁷ For he doesn't know that which will be; for who can tell him how it will\
-      \ be? "
-    8: "⁸ There is no man who has power over the spirit to contain the spirit; neither\
-      \ does he have power over the day of death. There is no discharge in war; neither\
-      \ shall wickedness deliver those who practice it. \n"
+    7: "⁷ For he doesn't know that which will be; for who can tell him how it will
+      be? "
+    8: "⁸ There is no man who has power over the spirit to contain the spirit; neither
+      does he have power over the day of death. There is no discharge in war; neither
+      shall wickedness deliver those who practice it. \n"
     9: '⁹ All this I have seen, and applied my mind to every work that is done under
       the sun. There is a time in which one man has power over another to his hurt. '
     10: '¹⁰ So I saw the wicked buried. Indeed they came also from holiness. They
@@ -337,15 +337,15 @@ Ecclesiastes:
     12: '¹² Though a sinner commits crimes a hundred times, and lives long, yet surely
       I know that it will be better with those who fear God, who are reverent before
       him. '
-    13: "¹³ But it shall not be well with the wicked, neither shall he lengthen days\
-      \ like a shadow, because he doesn't fear God. \n"
+    13: "¹³ But it shall not be well with the wicked, neither shall he lengthen days
+      like a shadow, because he doesn't fear God. \n"
     14: '¹⁴ There is a vanity which is done on the earth, that there are righteous
       men to whom it happens according to the work of the wicked. Again, there are
       wicked men to whom it happens according to the work of the righteous. I said
       that this also is vanity. '
-    15: "¹⁵ Then I commended mirth, because a man has no better thing under the sun\
-      \ than to eat, to drink, and to be joyful: for that will accompany him in his\
-      \ labor all the days of his life which God has given him under the sun. \n"
+    15: "¹⁵ Then I commended mirth, because a man has no better thing under the sun
+      than to eat, to drink, and to be joyful: for that will accompany him in his
+      labor all the days of his life which God has given him under the sun. \n"
     16: '¹⁶ When I applied my heart to know wisdom, and to see the business that is
       done on the earth (even though eyes see no sleep day or night), '
     17: ¹⁷ then I saw all the work of God, that man can't find out the work that is
@@ -353,58 +353,57 @@ Ecclesiastes:
       won't find it. Yes even though a wise man thinks he can comprehend it, he won't
       be able to find it.
   9:
-    1: "¹ For all this I laid to my heart, even to explore all this: that the righteous,\
-      \ and the wise, and their works, are in the hand of God; whether it is love\
-      \ or hatred, man doesn't know it; all is before them. "
-    2: "² All things come alike to all. There is one event to the righteous and to\
-      \ the wicked; to the good, to the clean, to the unclean, to him who sacrifices,\
-      \ and to him who doesn't sacrifice. As is the good, so is the sinner; he who\
-      \ takes an oath, as he who fears an oath. "
+    1: "¹ For all this I laid to my heart, even to explore all this: that the righteous,
+      and the wise, and their works, are in the hand of God; whether it is love or
+      hatred, man doesn't know it; all is before them. "
+    2: "² All things come alike to all. There is one event to the righteous and to
+      the wicked; to the good, to the clean, to the unclean, to him who sacrifices,
+      and to him who doesn't sacrifice. As is the good, so is the sinner; he who takes
+      an oath, as he who fears an oath. "
     3: '³ This is an evil in all that is done under the sun, that there is one event
       to all: yes also, the heart of the sons of men is full of evil, and madness
       is in their heart while they live, and after that they go to the dead. '
     4: '⁴ For to him who is joined with all the living there is hope; for a living
       dog is better than a dead lion. '
-    5: "⁵ For the living know that they will die, but the dead don't know anything,\
-      \ neither do they have any more a reward; for their memory is forgotten. "
-    6: "⁶ Also their love, their hatred, and their envy has perished long ago; neither\
-      \ do they any longer have a portion forever in anything that is done under the\
-      \ sun. \n"
+    5: "⁵ For the living know that they will die, but the dead don't know anything,
+      neither do they have any more a reward; for their memory is forgotten. "
+    6: "⁶ Also their love, their hatred, and their envy has perished long ago; neither
+      do they any longer have a portion forever in anything that is done under the
+      sun. \n"
     7: '⁷ Go your way-eat your bread with joy, and drink your wine with a merry heart;
       for God has already accepted your works. '
     8: "⁸ Let your garments be always white, and don't let your head lack oil. "
     9: '⁹ Live joyfully with the wife whom you love all the days of your life of vanity,
       which he has given you under the sun, all your days of vanity, for that is your
       portion in life, and in your labor in which you labor under the sun. '
-    10: "¹⁰ Whatever your hand finds to do, do it with your might; for there is no\
-      \ work, nor plan, nor knowledge, nor wisdom, in Sheol, where you are going.\
-      \ \n"
+    10: "¹⁰ Whatever your hand finds to do, do it with your might; for there is no
+      work, nor plan, nor knowledge, nor wisdom, in Sheol, where you are going. \n"
     11: '¹¹ I returned and saw under the sun that the race is not to the swift, nor
       the battle to the strong, neither yet bread to the wise, nor yet riches to men
       of understanding, nor yet favor to men of skill; but time and chance happen
       to them all. '
-    12: "¹² For man also doesn't know his time. As the fish that are taken in an evil\
-      \ net, and as the birds that are caught in the snare, even so are the sons of\
-      \ men snared in an evil time, when it falls suddenly on them. \n"
+    12: "¹² For man also doesn't know his time. As the fish that are taken in an evil
+      net, and as the birds that are caught in the snare, even so are the sons of
+      men snared in an evil time, when it falls suddenly on them. \n"
     13: '¹³ I have also seen wisdom under the sun in this way, and it seemed great
       to me. '
     14: '¹⁴ There was a little city, and few men within it; and a great king came
       against it, besieged it, and built great bulwarks against it. '
     15: '¹⁵ Now a poor wise man was found in it, and he by his wisdom delivered the
       city; yet no man remembered that same poor man. '
-    16: "¹⁶ Then I said, \"Wisdom is better than strength.\" Nevertheless the poor\
-      \ man's wisdom is despised, and his words are not heard. "
+    16: "¹⁶ Then I said, \"Wisdom is better than strength.\" Nevertheless the poor
+      man's wisdom is despised, and his words are not heard. "
     17: '¹⁷ The words of the wise heard in quiet are better than the cry of him who
       rules among fools. '
     18: ¹⁸ Wisdom is better than weapons of war; but one sinner destroys much good.
   10:
-    1: "¹ Dead flies cause the oil of the perfumer to produce an evil odor;\n    so\
-      \ does a little folly outweigh wisdom and honor.\n"
+    1: "¹ Dead flies cause the oil of the perfumer to produce an evil odor;\n    so
+      does a little folly outweigh wisdom and honor.\n"
     2: "² A wise man's heart is at his right hand,\nbut a fool's heart at his left. "
     3: '³ Yes also when the fool walks by the way, his understanding fails him, and
       he says to everyone that he is a fool. '
-    4: "⁴     If the spirit of the ruler rises up against you, don't leave your place;\
-      \ for gentleness lays great offenses to rest. \n"
+    4: "⁴     If the spirit of the ruler rises up against you, don't leave your place;
+      for gentleness lays great offenses to rest. \n"
     5: '⁵ There is an evil which I have seen under the sun, the sort of error which
       proceeds from the ruler. '
     6: '⁶ Folly is set in great dignity, and the rich sit in a low place. '
@@ -414,76 +413,76 @@ Ecclesiastes:
       be bitten by a snake. '
     9: '⁹ Whoever carves out stones may be injured by them. Whoever splits wood may
       be endangered by it. '
-    10: "¹⁰ If the ax is blunt, and one doesn't sharpen the edge, then he must use\
-      \ more strength; but skill brings success. \n"
-    11: "¹¹ If the snake bites before it is charmed, then is there no profit for the\
-      \ charmer's tongue. "
-    12: "¹² The words of a wise man's mouth are gracious; but a fool is swallowed\
-      \ by his own lips. "
+    10: "¹⁰ If the ax is blunt, and one doesn't sharpen the edge, then he must use
+      more strength; but skill brings success. \n"
+    11: "¹¹ If the snake bites before it is charmed, then is there no profit for the
+      charmer's tongue. "
+    12: "¹² The words of a wise man's mouth are gracious; but a fool is swallowed
+      by his own lips. "
     13: '¹³ The beginning of the words of his mouth is foolishness; and the end of
       his talk is mischievous madness. '
-    14: "¹⁴ A fool also multiplies words.\nMan doesn't know what will be; and that\
-      \ which will be after him, who can tell him? "
-    15: "¹⁵ The labor of fools wearies every one of them; for he doesn't know how\
-      \ to go to the city. \n"
-    16: "¹⁶ Woe to you, land, when your king is a child,\n    and your princes eat\
-      \ in the morning!\n"
-    17: "¹⁷ Happy are you, land, when your king is the son of nobles,\n    and your\
-      \ princes eat in due season,\n    for strength, and not for drunkenness!\n"
-    18: "¹⁸ By slothfulness the roof sinks in;\n    and through idleness of the hands\
-      \ the house leaks.\n"
+    14: "¹⁴ A fool also multiplies words.\nMan doesn't know what will be; and that
+      which will be after him, who can tell him? "
+    15: "¹⁵ The labor of fools wearies every one of them; for he doesn't know how
+      to go to the city. \n"
+    16: "¹⁶ Woe to you, land, when your king is a child,\n    and your princes eat
+      in the morning!\n"
+    17: "¹⁷ Happy are you, land, when your king is the son of nobles,\n    and your
+      princes eat in due season,\n    for strength, and not for drunkenness!\n"
+    18: "¹⁸ By slothfulness the roof sinks in;\n    and through idleness of the hands
+      the house leaks.\n"
     19: "¹⁹ A feast is made for laughter,\n    and wine makes the life glad;\n   \
       \ and money is the answer for all things.\n"
-    20: "²⁰ Don't curse the king, no, not in your thoughts;\n    and don't curse the\
-      \ rich in your bedroom:\n    for a bird of the sky may carry your voice,\n \
-      \   and that which has wings may tell the matter."
+    20: "²⁰ Don't curse the king, no, not in your thoughts;\n    and don't curse the
+      rich in your bedroom:\n    for a bird of the sky may carry your voice,\n   \
+      \ and that which has wings may tell the matter."
   11:
     1: "¹ Cast your bread on the waters;\n    for you shall find it after many days.\n"
-    2: "² Give a portion to seven, yes, even to eight;\n    for you don't know what\
-      \ evil will be on the earth.\n"
+    2: "² Give a portion to seven, yes, even to eight;\n    for you don't know what
+      evil will be on the earth.\n"
     3: "³ If the clouds are full of rain, they empty themselves on the earth;\n  \
-      \  and if a tree falls toward the south, or toward the north,\n    in the place\
-      \ where the tree falls, there shall it be.\n"
-    4: "⁴ He who observes the wind won't sow;\n    and he who regards the clouds won't\
-      \ reap.\n"
-    5: "⁵ As you don't know what is the way of the wind,\n    nor how the bones grow\
-      \ in the womb of her who is with child;\n    even so you don't know the work\
-      \ of God who does all.\n"
-    6: "⁶ In the morning sow your seed,\n    and in the evening don't withhold your\
-      \ hand;\n    for you don't know which will prosper, whether this or that,\n\
-      \    or whether they both will be equally good.\n"
-    7: "⁷ Truly the light is sweet,\n    and it is a pleasant thing for the eyes to\
-      \ see the sun.\n"
-    8: "⁸ Yes, if a man lives many years, let him rejoice in them all;\n    but let\
-      \ him remember the days of darkness, for they shall be many.\n    All that comes\
-      \ is vanity.\n"
-    9: "⁹ Rejoice, young man, in your youth,\n    and let your heart cheer you in\
-      \ the days of your youth,\n    and walk in the ways of your heart,\n    and\
-      \ in the sight of your eyes;\n    but know that for all these things God will\
-      \ bring you into judgment.\n"
-    10: "¹⁰ Therefore remove sorrow from your heart,\n    and put away evil from your\
-      \ flesh;\n    for youth and the dawn of life are vanity."
+      \  and if a tree falls toward the south, or toward the north,\n    in the place
+      where the tree falls, there shall it be.\n"
+    4: "⁴ He who observes the wind won't sow;\n    and he who regards the clouds won't
+      reap.\n"
+    5: "⁵ As you don't know what is the way of the wind,\n    nor how the bones grow
+      in the womb of her who is with child;\n    even so you don't know the work of
+      God who does all.\n"
+    6: "⁶ In the morning sow your seed,\n    and in the evening don't withhold your
+      hand;\n    for you don't know which will prosper, whether this or that,\n  \
+      \  or whether they both will be equally good.\n"
+    7: "⁷ Truly the light is sweet,\n    and it is a pleasant thing for the eyes to
+      see the sun.\n"
+    8: "⁸ Yes, if a man lives many years, let him rejoice in them all;\n    but let
+      him remember the days of darkness, for they shall be many.\n    All that comes
+      is vanity.\n"
+    9: "⁹ Rejoice, young man, in your youth,\n    and let your heart cheer you in
+      the days of your youth,\n    and walk in the ways of your heart,\n    and in
+      the sight of your eyes;\n    but know that for all these things God will bring
+      you into judgment.\n"
+    10: "¹⁰ Therefore remove sorrow from your heart,\n    and put away evil from your
+      flesh;\n    for youth and the dawn of life are vanity."
   12:
-    1: "¹ Remember also your Creator in the days of your youth,\n    before the evil\
-      \ days come, and the years draw near,\n    when you will say, \"I have no pleasure\
-      \ in them;\"\n"
-    2: "² Before the sun, the light, the moon, and the stars are darkened,\n    and\
-      \ the clouds return after the rain;\n"
-    3: "³ in the day when the keepers of the house shall tremble,\n    and the strong\
-      \ men shall bow themselves,\n    and the grinders cease because they are few,\n\
+    1: "¹ Remember also your Creator in the days of your youth,\n    before the evil
+      days come, and the years draw near,\n    when you will say, \"I have no pleasure
+      in them;\"\n"
+    2: "² Before the sun, the light, the moon, and the stars are darkened,\n    and
+      the clouds return after the rain;\n"
+    3: "³ in the day when the keepers of the house shall tremble,\n    and the strong
+      men shall bow themselves,\n    and the grinders cease because they are few,\n\
       \    and those who look out of the windows are darkened,\n"
-    4: "⁴ and the doors shall be shut in the street;\n    when the sound of the grinding\
-      \ is low,\n    and one shall rise up at the voice of a bird,\n    and all the\
-      \ daughters of music shall be brought low;\n"
+    4: "⁴ and the doors shall be shut in the street;\n    when the sound of the grinding
+      is low,\n    and one shall rise up at the voice of a bird,\n    and all the
+      daughters of music shall be brought low;\n"
     5: "⁵ yes, they shall be afraid of heights,\n    and terrors will be on the way;\n\
-      \    and the almond tree shall blossom,\n    and the grasshopper shall be a\
-      \ burden,\n    and desire shall fail;\n    because man goes to his everlasting\
-      \ home,\n    and the mourners go about the streets:\n"
+      \    and the almond tree shall blossom,\n    and the grasshopper shall be a
+      burden,\n    and desire shall fail;\n    because man goes to his everlasting
+      home,\n    and the mourners go about the streets:\n"
     6: "⁶ before the silver cord is severed,\n    or the golden bowl is broken,\n\
-      \    or the pitcher is broken at the spring,\n    or the wheel broken at the\
-      \ cistern,\n"
-    7: "⁷ and the dust returns to the earth as it was,\n    and the spirit returns\
-      \ to God who gave it.\n"
+      \    or the pitcher is broken at the spring,\n    or the wheel broken at the
+      cistern,\n"
+    7: "⁷ and the dust returns to the earth as it was,\n    and the spirit returns
+      to God who gave it.\n"
     8: "⁸     \"Vanity of vanities,\" says the Preacher.\n    \"All is vanity!\" \n"
     9: '⁹ Further, because the Preacher was wise, he still taught the people knowledge.
       Yes, he pondered, sought out, and set in order many proverbs. '
@@ -491,8 +490,8 @@ Ecclesiastes:
       blamelessly, words of truth. '
     11: '¹¹ The words of the wise are like goads; and like nails well fastened are
       words from the masters of assemblies, which are given from one shepherd. '
-    12: "¹² Furthermore, my son, be admonished: of making many books there is no end;\
-      \ and much study is a weariness of the flesh. \n"
+    12: "¹² Furthermore, my son, be admonished: of making many books there is no end;
+      and much study is a weariness of the flesh. \n"
     13: '¹³ This is the end of the matter. All has been heard. Fear God and keep his
       commandments; for this is the whole duty of man. '
     14: ¹⁴ For God will bring every work into judgment, with every hidden thing, whether

--- a/test/system_tests_bible_translations.py
+++ b/test/system_tests_bible_translations.py
@@ -2,7 +2,7 @@ import unittest
 import multiprocessing
 import sys
 sys.path.append('../')
-from meaningless import WebExtractor, YAMLDownloader, YAMLExtractor
+from meaningless import WebExtractor, JSONDownloader, JSONExtractor
 from meaningless.utilities import common
 
 
@@ -79,9 +79,9 @@ class UnitTests(unittest.TestCase):
         download_path = f'./tmp/check_omitted_passages/{translation}'
         # Downloading the books with a process map is somewhat faster than using multiple daemon processes to
         # acquire each book sequentially.
-        downloader = YAMLDownloader(translation=translation, enable_multiprocessing=False,
+        downloader = JSONDownloader(translation=translation, enable_multiprocessing=False,
                                     default_directory=download_path)
-        bible = YAMLExtractor(translation=translation, default_directory=download_path)
+        bible = JSONExtractor(translation=translation, default_directory=download_path)
 
         if common.BIBLE_TRANSLATIONS[translation]['Language'] == 'Español':
             books_with_omissions = ['Mateo', 'Marcos', 'Lucas', 'Juan', 'Hechos', 'Romanos']


### PR DESCRIPTION
Uncovered when using ruamel.yaml 0.17.26 to run the unit tests, which were failing the last couple of weekly automated test workflows.

Some Web Extractor unit tests were failing because the behaviour of ruamel.yaml has changed in relation to spaces that are the last or first character of a line. Using the existing YAML files (generated using an older ruamel.yaml version) meant that some spaces were doubling up, so this could be a potential issue noticed in actual usage environments.

The system tests were failing for a similar reason, but this time using the JSON Downloader and Extractor seems to be a better fix as it doesn't exhibit this new whitespace handling behaviour.