### PR TITLE
1.2.0: Add GitHub Actions workflow for publishing to Pypi

### DIFF
--- a/.github/workflows/build_and_publish_package.yaml
+++ b/.github/workflows/build_and_publish_package.yaml
@@ -28,7 +28,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r REQUIREMENTS.txt
           pip install -r REQUIREMENTS_DEVELOPMENT.txt
-          pip install twine
+          pip install -r REQUIREMENTS_PYPI.txt
       - name: Build Meaningless library
         run: |
           python -m build

--- a/.github/workflows/build_and_publish_package.yaml
+++ b/.github/workflows/build_and_publish_package.yaml
@@ -13,6 +13,7 @@ on:
 jobs:
   Build-and-Publish-Package:
     runs-on: windows-latest
+    environment: pypi-publishing
     name: Build and Publish Meaningless package
     env:
       TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}

--- a/.github/workflows/build_and_publish_package.yaml
+++ b/.github/workflows/build_and_publish_package.yaml
@@ -1,0 +1,49 @@
+name: Build and Publish Meaningless package
+on:
+  workflow_dispatch:
+    inputs:
+      publish_type:
+        type: choice
+        description: 'Specify which package index to publish to'
+        required: true
+        options:
+        - Build package only (no publishing)
+        - test.pypi.org
+        - pypi.org
+jobs:
+  Build-and-Publish-Package:
+    runs-on: windows-latest
+    name: Build and Publish Meaningless package
+    env:
+      TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r REQUIREMENTS.txt
+          pip install -r REQUIREMENTS_DEVELOPMENT.txt
+          pip install twine
+      - name: Build Meaningless library
+        run: |
+          python -m build
+      - if: github.event.inputs.publish_type == 'test.pypi.org'
+        name: Publish Meaningless package to Test Python Package Index
+        run: |
+          python -m twine upload --repository testpypi dist\*
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD_TEST }}
+      - if: github.event.inputs.publish_type == 'pypi.org'
+        name: Publish Meaningless package to Python Package Index
+        run: |
+          python -m twine upload dist\*
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD_PROD }}
+      - name: Report job status
+        run: |
+          echo "This job's status is ${{ job.status }}."

--- a/REQUIREMENTS_PYPI.txt
+++ b/REQUIREMENTS_PYPI.txt
@@ -1,0 +1,2 @@
+# These are additional modules used as part of publishing Meaningless to a Pypi instance
+twine>=4.0.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,11 @@ requires-python = '>=3.10'
 [tool.setuptools]
 # This disables module auto discovery, since some top-level folders are not supposed to be packaged
 py-modules = []
-packages = ['meaningless']
+
+[tool.setuptools.packages.find]
+# This is needed for dynamically deriving the version from a constant
+where = ['.']
+include = ['meaningless*']
 
 [tool.setuptools.dynamic]
 version = {attr = 'meaningless.utilities.common.MEANINGLESS_VERSION'}


### PR DESCRIPTION
Currently, publishing the Meaningless package to either https://test.pypi.org/ or https://pypi.org/ involves running a series of commands locally and then manually supplying the relevant Pypi username and secret to upload using `twine`.

This pull request offloads the complexity of those steps into a GitHub Actions workflow that is able to replicate the same procedure with just a few clicks in the GitHub user interface.

Also pinning `twine` to a minimum version to ensure some level of stability when run through GitHub Actions.